### PR TITLE
Spaces in front of shared URLs

### DIFF
--- a/Send to Other/ShareViewController.swift
+++ b/Send to Other/ShareViewController.swift
@@ -152,11 +152,13 @@ class ShareViewController: UIViewController, MFMessageComposeViewControllerDeleg
 								else if let url = item as? URL {
 									let text = url.absoluteString
 									print("[ShareViewController] Attaching as text…")
-									messageController.body = "\(messageController.body ?? "") \(text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines))"
+                                    let body = [messageController.body, text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)].flatMap { $0 }.filter { !$0.isEmpty }.joined(separator: " ")
+									messageController.body = body
 								}
 								else if let text = item as? String {
 									print("[ShareViewController] Attaching as text…")
-									messageController.body = "\(messageController.body ?? "") \(text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines))"
+                                    let body = [messageController.body, text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)].flatMap { $0 }.filter { !$0.isEmpty }.joined(separator: " ")
+                                    messageController.body = body
 								}
 								else if let data = item as? Data, let ext = UTTypeCopyPreferredTagWithClass(typeIdentifier, kUTTagClassFilenameExtension)?.takeRetainedValue() {
 									print("[ShareViewController] Attaching as data…")

--- a/Send to Other/ShareViewController.swift
+++ b/Send to Other/ShareViewController.swift
@@ -67,7 +67,7 @@ class ShareViewController: UIViewController, MFMessageComposeViewControllerDeleg
 	}
 
 	fileprivate var handling = false
-	
+
 	fileprivate func handleExtensionRequest() {
 		guard let context = self.extensionContext else {
 			return
@@ -152,13 +152,13 @@ class ShareViewController: UIViewController, MFMessageComposeViewControllerDeleg
 								else if let url = item as? URL {
 									let text = url.absoluteString
 									print("[ShareViewController] Attaching as text…")
-                                    let body = [messageController.body, text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)].flatMap { $0 }.filter { !$0.isEmpty }.joined(separator: " ")
+									let body = [messageController.body, text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)].flatMap { $0 }.filter { !$0.isEmpty }.joined(separator: " ")
 									messageController.body = body
 								}
 								else if let text = item as? String {
 									print("[ShareViewController] Attaching as text…")
-                                    let body = [messageController.body, text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)].flatMap { $0 }.filter { !$0.isEmpty }.joined(separator: " ")
-                                    messageController.body = body
+									let body = [messageController.body, text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)].flatMap { $0 }.filter { !$0.isEmpty }.joined(separator: " ")
+									messageController.body = body
 								}
 								else if let data = item as? Data, let ext = UTTypeCopyPreferredTagWithClass(typeIdentifier, kUTTagClassFilenameExtension)?.takeRetainedValue() {
 									print("[ShareViewController] Attaching as data…")


### PR DESCRIPTION
Hi,

This is a great app! I particularly like the "Share with Other" extension.

I noticed that when I share URLs with my SO there's a space at the front, though. The message it tries to send is " https://example.com". The single space leads to an extra bubble in iMessage:

![img_6484](https://cloud.githubusercontent.com/assets/790199/25732626/14e895fe-3195-11e7-9ee5-df5a5896e5fe.PNG)

Thought it was something I should have a go at fixing. 

Let me know what you think!
